### PR TITLE
Add simple AI tool builder UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # Toolz
-Lotz of toolz
+
+A collection of small AI utilities. The repository includes a simple web UI that can be hosted with GitHub Pages. The UI lets you describe a tool you want and uses OpenAI's API to generate a code snippet.
+
+## Running the site
+
+1. Place your files under the `docs/` directory so GitHub Pages can serve them.
+2. Set your OpenAI API key in the browser by running the following in the dev console:
+
+```javascript
+localStorage.setItem('OPENAI_API_KEY', 'your-api-key');
+```
+
+3. Open `docs/index.html` in the browser (or enable GitHub Pages in the repo settings).
+4. Type a description of the AI tool you'd like and click **Generate Tool**.

--- a/docs/app.js
+++ b/docs/app.js
@@ -1,0 +1,39 @@
+document.getElementById('generate').addEventListener('click', async () => {
+    const prompt = document.getElementById('prompt').value;
+    if (!prompt.trim()) {
+        alert('Please enter a description.');
+        return;
+    }
+
+    const apiKey = localStorage.getItem('OPENAI_API_KEY');
+    if (!apiKey) {
+        alert('Set your OpenAI API key in localStorage under OPENAI_API_KEY.');
+        return;
+    }
+
+    const resultEl = document.getElementById('result');
+    resultEl.textContent = 'Generating...';
+
+    try {
+        const response = await fetch('https://api.openai.com/v1/chat/completions', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${apiKey}`
+            },
+            body: JSON.stringify({
+                model: 'gpt-3.5-turbo',
+                messages: [
+                    { role: 'system', content: 'You are an assistant that creates simple AI tool code snippets.' },
+                    { role: 'user', content: prompt }
+                ]
+            })
+        });
+        const data = await response.json();
+        const text = data.choices && data.choices[0] && data.choices[0].message && data.choices[0].message.content;
+        resultEl.textContent = text || 'No response';
+    } catch (err) {
+        console.error(err);
+        resultEl.textContent = 'Error retrieving response.';
+    }
+});

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AI Tool Builder</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>AI Tool Builder</h1>
+    <p>Describe the tool you want to build and let the AI suggest code.</p>
+    <textarea id="prompt" rows="5" placeholder="e.g., a Python script that summarizes text..."></textarea>
+    <button id="generate">Generate Tool</button>
+    <pre id="result"></pre>
+
+    <script src="app.js"></script>
+</body>
+</html>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,16 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 2rem;
+}
+textarea {
+    width: 100%;
+    margin-bottom: 1rem;
+}
+button {
+    padding: 0.5rem 1rem;
+}
+pre {
+    background-color: #f0f0f0;
+    padding: 1rem;
+    white-space: pre-wrap;
+}


### PR DESCRIPTION
## Summary
- create `docs/` folder for GitHub Pages
- add simple HTML/JS/CSS to allow generating code snippets with OpenAI API
- update README with instructions

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684d291ed30c832a8d20108c56160c4c