### PR TITLE
Replace API calls with template-based snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,9 @@
 # Toolz
 
-A collection of small AI utilities. The repository includes a simple web UI that can be hosted with GitHub Pages. The UI lets you describe a tool you want and uses OpenAI's API to generate a code snippet.
+A collection of small AI utilities. The repository includes a simple web UI that can be hosted with GitHub Pages. The rebuilt UI suggests code snippets from a small template library so no API key is required.
 
 ## Running the site
 
 1. Place your files under the `docs/` directory so GitHub Pages can serve them.
-2. Set your OpenAI API key in the browser by running the following in the dev console:
-
-```javascript
-localStorage.setItem('OPENAI_API_KEY', 'your-api-key');
-```
-
-3. Open `docs/index.html` in the browser (or enable GitHub Pages in the repo settings).
-4. Type a description of the AI tool you'd like and click **Generate Tool**.
+2. Open `docs/index.html` in the browser (or enable GitHub Pages in the repo settings).
+3. Type a description of the tool you'd like and click **Generate Tool** to see a matching code snippet.

--- a/docs/app.js
+++ b/docs/app.js
@@ -1,39 +1,29 @@
-document.getElementById('generate').addEventListener('click', async () => {
-    const prompt = document.getElementById('prompt').value;
+const snippets = [
+    {
+        keywords: ['summarize', 'summary'],
+        code: `# Python text summarizer\nfrom gensim.summarization import summarize\ntext = "Your text here"\nprint(summarize(text))`
+    },
+    {
+        keywords: ['translate', 'translation'],
+        code: `# Python text translator\nfrom googletrans import Translator\ntranslator = Translator()\nresult = translator.translate("Hello world", dest='es')\nprint(result.text)`
+    },
+    {
+        keywords: ['fibonacci'],
+        code: `# Python Fibonacci sequence\nn = 10\nfib = [0, 1]\nfor i in range(2, n):\n    fib.append(fib[-1] + fib[-2])\nprint(fib)`
+    }
+];
+
+document.getElementById('generate').addEventListener('click', () => {
+    const prompt = document.getElementById('prompt').value.toLowerCase();
     if (!prompt.trim()) {
         alert('Please enter a description.');
         return;
     }
-
-    const apiKey = localStorage.getItem('OPENAI_API_KEY');
-    if (!apiKey) {
-        alert('Set your OpenAI API key in localStorage under OPENAI_API_KEY.');
-        return;
-    }
-
     const resultEl = document.getElementById('result');
-    resultEl.textContent = 'Generating...';
-
-    try {
-        const response = await fetch('https://api.openai.com/v1/chat/completions', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'Authorization': `Bearer ${apiKey}`
-            },
-            body: JSON.stringify({
-                model: 'gpt-3.5-turbo',
-                messages: [
-                    { role: 'system', content: 'You are an assistant that creates simple AI tool code snippets.' },
-                    { role: 'user', content: prompt }
-                ]
-            })
-        });
-        const data = await response.json();
-        const text = data.choices && data.choices[0] && data.choices[0].message && data.choices[0].message.content;
-        resultEl.textContent = text || 'No response';
-    } catch (err) {
-        console.error(err);
-        resultEl.textContent = 'Error retrieving response.';
+    const match = snippets.find(snippet => snippet.keywords.some(k => prompt.includes(k)));
+    if (match) {
+        resultEl.textContent = match.code;
+    } else {
+        resultEl.textContent = '# Example Python script\nprint("Hello, world!")';
     }
 });

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,12 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>AI Tool Builder</title>
+    <title>Simple Tool Builder</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <h1>AI Tool Builder</h1>
-    <p>Describe the tool you want to build and let the AI suggest code.</p>
+    <h1>Simple Tool Builder</h1>
+    <p>Describe the tool you want to build and get a matching code snippet. No API key required.</p>
     <textarea id="prompt" rows="5" placeholder="e.g., a Python script that summarizes text..."></textarea>
     <button id="generate">Generate Tool</button>
     <pre id="result"></pre>


### PR DESCRIPTION
## Summary
- remove OpenAI dependency from the web page
- offer simple template snippets instead
- update README to describe the new approach

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684d2cf95558832a9b271923d5e5a33e