### PR TITLE
Improve GitHub Pages UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,4 @@ A collection of small AI utilities. The repository includes a simple web UI that
 1. Place your files under the `docs/` directory so GitHub Pages can serve them.
 2. Open `docs/index.html` in the browser (or enable GitHub Pages in the repo settings).
 3. Type a description of the tool you'd like and click **Generate Tool** to see a matching code snippet.
+4. Use the **Copy Code** button to quickly copy the snippet.

--- a/docs/app.js
+++ b/docs/app.js
@@ -13,6 +13,8 @@ const snippets = [
     }
 ];
 
+const copyBtn = document.getElementById('copy');
+
 document.getElementById('generate').addEventListener('click', () => {
     const prompt = document.getElementById('prompt').value.toLowerCase();
     if (!prompt.trim()) {
@@ -26,4 +28,12 @@ document.getElementById('generate').addEventListener('click', () => {
     } else {
         resultEl.textContent = '# Example Python script\nprint("Hello, world!")';
     }
+    copyBtn.style.display = 'inline-block';
+});
+
+copyBtn.addEventListener('click', () => {
+    const code = document.getElementById('result').textContent;
+    navigator.clipboard.writeText(code).then(() => {
+        alert('Code copied to clipboard');
+    });
 });

--- a/docs/index.html
+++ b/docs/index.html
@@ -7,11 +7,15 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <h1>Simple Tool Builder</h1>
-    <p>Describe the tool you want to build and get a matching code snippet. No API key required.</p>
-    <textarea id="prompt" rows="5" placeholder="e.g., a Python script that summarizes text..."></textarea>
-    <button id="generate">Generate Tool</button>
-    <pre id="result"></pre>
+    <div class="container">
+        <h1>Simple Tool Builder</h1>
+        <p>Describe the tool you want to build and get a matching code snippet. No API key required.</p>
+        <label for="prompt">Tool description</label>
+        <textarea id="prompt" rows="5" placeholder="e.g., a Python script that summarizes text..."></textarea>
+        <button id="generate">Generate Tool</button>
+        <button id="copy" style="display:none;">Copy Code</button>
+        <pre id="result"></pre>
+    </div>
 
     <script src="app.js"></script>
 </body>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,16 +1,38 @@
 body {
     font-family: Arial, sans-serif;
-    margin: 2rem;
+    margin: 0;
+    padding: 0;
+    background-color: #fafafa;
 }
+
+.container {
+    max-width: 600px;
+    margin: 2rem auto;
+    padding: 1rem;
+}
+
+label {
+    font-weight: bold;
+    display: block;
+    margin-bottom: 0.5rem;
+}
+
 textarea {
     width: 100%;
     margin-bottom: 1rem;
+    font-size: 1rem;
 }
+
 button {
     padding: 0.5rem 1rem;
+    font-size: 1rem;
+    margin-right: 0.5rem;
 }
+
 pre {
     background-color: #f0f0f0;
     padding: 1rem;
     white-space: pre-wrap;
+    min-height: 8rem;
+    margin-top: 1rem;
 }


### PR DESCRIPTION
## Summary
- add a container layout and label for the tool prompt
- style page elements for a cleaner layout
- enable copying snippets to clipboard
- document the new copy button

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684d9cdb76e4832a99e0622fc264a5e0