### PR TITLE
Simplify public UI

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -13,9 +13,6 @@ const snippets = [
     }
 ];
 
-const copyBtn = document.getElementById('copy');
-const downloadBtn = document.getElementById('download');
-
 document.getElementById('generate').addEventListener('click', () => {
     const prompt = document.getElementById('prompt').value.toLowerCase();
     if (!prompt.trim()) {
@@ -29,27 +26,4 @@ document.getElementById('generate').addEventListener('click', () => {
     } else {
         resultEl.textContent = '# Example Python script\nprint("Hello, world!")';
     }
-    copyBtn.style.display = 'inline-block';
-    downloadBtn.style.display = 'inline-block';
-});
-
-copyBtn.addEventListener('click', () => {
-    const code = document.getElementById('result').textContent;
-    navigator.clipboard.writeText(code).then(() => {
-        alert('Code copied to clipboard');
-    });
-});
-
-downloadBtn.addEventListener('click', () => {
-    const code = document.getElementById('result').textContent;
-    if (!code.trim()) {
-        alert('Generate code first.');
-        return;
-    }
-    const zip = new JSZip();
-    zip.file('README.md', '# Toolz Generated Repo\n\nYour idea: ' + document.getElementById('prompt').value);
-    zip.file('main.py', code);
-    zip.generateAsync({ type: 'blob' }).then(content => {
-        saveAs(content, 'toolz_repo.zip');
-    });
 });

--- a/docs/index.html
+++ b/docs/index.html
@@ -8,19 +8,11 @@
 </head>
 <body>
     <div class="container">
-        <h1>Toolz</h1>
-        <p>Type your idea and get starter code. It's yours to keep.</p>
-        <label for="prompt">Your idea</label>
-        <textarea id="prompt" rows="5" placeholder="e.g., a Python script that summarizes text..."></textarea>
+        <textarea id="prompt" rows="5" placeholder="Enter your idea..."></textarea>
         <button id="generate">Generate</button>
-        <button id="copy" style="display:none;">Copy Code</button>
-        <button id="download" style="display:none;">Download Repo</button>
         <pre id="result"></pre>
-        <p class="small">Need a full repo with AI-generated code? Run <code>python generate_repo.py</code> as described in the <a href="../README.md">README</a>.</p>
     </div>
 
-    <script src="https://cdn.jsdelivr.net/npm/jszip@3.10.0/dist/jszip.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/file-saver@2.0.5/dist/FileSaver.min.js"></script>
     <script src="app.js"></script>
 </body>
 </html>

--- a/docs/style.css
+++ b/docs/style.css
@@ -5,21 +5,11 @@ body {
     background-color: #fafafa;
 }
 
-h1 {
-    margin-top: 0;
-}
-
 .container {
     max-width: 600px;
     margin: 2rem auto;
     padding: 1rem;
     text-align: center;
-}
-
-label {
-    font-weight: bold;
-    display: block;
-    margin-bottom: 0.5rem;
 }
 
 textarea {
@@ -40,9 +30,4 @@ pre {
     white-space: pre-wrap;
     min-height: 8rem;
     margin-top: 1rem;
-}
-
-.small {
-    font-size: 0.9rem;
-    margin-top: 0.5rem;
 }


### PR DESCRIPTION
## Summary
- trim README links and extra buttons from the website
- reduce the index page to just a prompt box, generate button, and output area
- remove unused styles and JS code for copy/download functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dec0282cc832ab1b021041717ac2b