### PR TITLE
Enable GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,30 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Upload docs artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: './docs'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Toolz helps you discover free open source technology for your project ideas. Typ
 This repository includes a small web interface (served from the `docs/` folder) and a command-line script, `search_github.py`, that uses the GitHub search API.
 
 ## Web interface
-Open `docs/index.html` in your browser or enable GitHub Pages on this repository. Enter your idea and the page will list the top GitHub projects related to it.
+Open `docs/index.html` in your browser or enable GitHub Pages to host the site. The repository includes a workflow that publishes the `docs/` directory to GitHub Pages whenever changes are pushed to `main`. Once Pages is enabled, your site will be available at `https://<username>.github.io/Toolz/`.
+Enter your idea in the search box and the page will list the top GitHub projects related to it.
 
 ## Command-line usage
 1. Install the dependencies:


### PR DESCRIPTION
## Summary
- add GitHub Pages deployment workflow
- document automatic page deployment in README

## Testing
- `python -m py_compile search_github.py`

------
https://chatgpt.com/codex/tasks/task_e_684df34fdfc4832a916ce943b45de506