### PR TITLE
Fix caching with GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,6 @@ Enter your idea in the search box and the page will list the top GitHub projects
    The script prints links to relevant repositories.
 
 Set the `GITHUB_TOKEN` environment variable to use an API token (optional but recommended to avoid rate limits).
+
+## Troubleshooting
+If changes to the backend appear on GitHub but the published site still shows an old version, your browser may be caching the files. The `index.html` page disables caching, but some browsers may still require a hard refresh. Try reloading with `Ctrl+Shift+R` (or `Cmd+Shift+R` on macOS) to force the latest UI.

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,6 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
     <title>Toolz Finder</title>
     <link rel="stylesheet" href="style.css">
 </head>


### PR DESCRIPTION
## Summary
- disable caching for GitHub Pages with meta headers
- document cache troubleshooting for users

## Testing
- `python -m py_compile search_github.py`


------
https://chatgpt.com/codex/tasks/task_e_684df51a28a4832a9e45ecb64dc9f042