### PR TITLE
Improve tokenomics fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ Toolz is a collection of lightweight, AI-powered browser tools for crypto invest
 
 ## Available Tools
 
-- **Ponzology** – analyzes tokenomics descriptions for potentially predatory or unsustainable patterns, highlighting high APY claims and large team allocations. Visit [docs/ponzology](docs/ponzology/) to try it. When fetching tokenomics by contract address, Ponzology first queries Coingecko and falls back to CoinMarketCap's public API.
+- **Ponzology** – analyzes tokenomics descriptions for potentially predatory or unsustainable patterns, highlighting high APY claims and large team allocations. Visit [docs/ponzology](docs/ponzology/) to try it. When fetching tokenomics by contract address, Ponzology first queries Coingecko and falls back to CoinMarketCap's public API. Supply details are included alongside the description.
 
 The project is designed so new tools can be added easily under the `docs/` directory. Simply create a folder for your tool containing an `index.html`, `style.css`, and `script.js`.


### PR DESCRIPTION
## Summary
- include basic supply figures when fetching tokenomics by contract address
- note new supply info in README

## Testing
- `node -e "require('./docs/ponzology/script.js')"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_684e22361b70832a93e98f4422ee8c0b