### PR TITLE
Improve Ponzology button spacing

### DIFF
--- a/docs/ponzology/style.css
+++ b/docs/ponzology/style.css
@@ -50,6 +50,10 @@ button {
     border-radius: 4px;
 }
 
+#fetch {
+    margin-bottom: 0.5rem;
+}
+
 button:hover {
     background: #005a99;
 }


### PR DESCRIPTION
## Summary
- add margin under the `Fetch Tokenomics` button for clearer spacing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e24e9aa90832aa8ae950ba39f7f78