### PR TITLE
Improve tokenomics data gathering

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ Toolz is a collection of lightweight, AI-powered browser tools for crypto invest
 
 ## Available Tools
 
-- **Ponzology** – analyzes tokenomics descriptions for potentially predatory or unsustainable patterns, highlighting high APY claims and large team allocations. Visit [docs/ponzology](docs/ponzology/) to try it. When fetching tokenomics by contract address, Ponzology first queries Coingecko and falls back to CoinMarketCap's public API. Supply details are included alongside the description.
+- **Ponzology** – analyzes tokenomics descriptions for potentially predatory or unsustainable patterns, highlighting high APY claims and large team allocations. Visit [docs/ponzology](docs/ponzology/) to try it. When fetching tokenomics by contract address, Ponzology now pulls data from Coingecko, CoinMarketCap and the public Ethplorer API so supply information and basic metadata like holder counts are included alongside the description.
 
 The project is designed so new tools can be added easily under the `docs/` directory. Simply create a folder for your tool containing an `index.html`, `style.css`, and `script.js`.


### PR DESCRIPTION
## Summary
- broaden tokenomics fetch in Ponzology to use Ethplorer in addition to Coingecko/CoinMarketCap
- include metadata like decimals, holder counts and website
- document the updated data sources in the README

## Testing
- `curl https://api.ethplorer.io/getTokenInfo/0xdAC17F958D2ee523a2206206994597C13D831ec7?apiKey=freekey | head`


------
https://chatgpt.com/codex/tasks/task_e_684e28fb15e4832a95de7922ec0ee11c