### PR TITLE
Add dark mode styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Toolz is a collection of lightweight, AI-powered browser tools for crypto investors. Each tool is completely client-side and requires no dependencies or backend.
 
+All pages support dark mode automatically via the user's system preference.
+
 ## Available Tools
 
 - **Ponzology** – analyzes tokenomics descriptions for potentially predatory or unsustainable patterns, highlighting high APY claims and large team allocations. Visit [docs/ponzology](docs/ponzology/) to try it. When fetching tokenomics by contract address, Ponzology now pulls data from Coingecko, CoinMarketCap and the public Ethplorer API so supply information and basic metadata like holder counts are included alongside the description.

--- a/docs/ponzology/style.css
+++ b/docs/ponzology/style.css
@@ -94,3 +94,38 @@ button:hover {
 .back-button:hover {
     text-decoration: underline;
 }
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background: #1e1e1e;
+        color: #ddd;
+    }
+
+    .container {
+        background: #2c2c2c;
+        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
+    }
+
+    .subtitle {
+        color: #aaa;
+    }
+
+    textarea,
+    input[type="text"] {
+        background: #333;
+        color: #fff;
+        border: 1px solid #555;
+    }
+
+    button {
+        background: #1c70d6;
+    }
+
+    button:hover {
+        background: #0f406c;
+    }
+
+    .back-button {
+        color: #66aaff;
+    }
+}

--- a/docs/style.css
+++ b/docs/style.css
@@ -3,6 +3,7 @@ body {
     margin: 0;
     padding: 1rem;
     background: #f4f4f4;
+    color: #000;
 }
 
 header {
@@ -43,4 +44,28 @@ header {
 
 h1 {
     margin-top: 0;
+}
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background: #1e1e1e;
+        color: #ddd;
+    }
+
+    .tool-list a {
+        color: #66aaff;
+    }
+
+    .tool-button {
+        background: #1c70d6;
+        color: #fff !important;
+    }
+
+    .tool-button:hover {
+        background: #0f406c;
+    }
+
+    .desc {
+        color: #ccc;
+    }
 }


### PR DESCRIPTION
## Summary
- support dark color scheme across Toolz pages
- document dark mode in README

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684e2b110794832a97efc5d4cbb7992a