### PR TITLE
Improve Ponzology token checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ Toolz is a collection of lightweight, AI-powered browser tools for crypto invest
 
 ## Available Tools
 
-- **Ponzology** – analyzes tokenomics descriptions for potentially predatory or unsustainable patterns, highlighting high APY claims and large team allocations. Visit [docs/ponzology](docs/ponzology/) to try it. When fetching tokenomics by contract address, Ponzology now pulls data from Coingecko, CoinMarketCap and the public Ethplorer API so supply information and basic metadata like holder counts are included alongside the description.
+- **Ponzology** – analyzes tokenomics descriptions for potentially predatory or unsustainable patterns, highlighting high APY claims, large team allocations and other irregularities. Visit [docs/ponzology](docs/ponzology/) to try it. When fetching tokenomics by contract address, Ponzology now pulls data from Coingecko, CoinMarketCap and the public Ethplorer API so supply information and basic metadata like holder counts are included alongside the description. The analysis checks for unrealistic supply numbers, missing max supply and other warning signs.
 
 The project is designed so new tools can be added easily under the `docs/` directory. Simply create a folder for your tool containing an `index.html`, `style.css`, and `script.js`.


### PR DESCRIPTION
## Summary
- extend list of red flag phrases in Ponzology
- analyze supply data from fetched text for large supply, missing max supply and other issues
- adjust rating logic to account for new concerns
- document enhanced checks in README

## Testing
- `node --check docs/ponzology/script.js`

------
https://chatgpt.com/codex/tasks/task_e_684e2b5739c8832a8c8a885b62e00df7