### PR TITLE
Add case-insensitive redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,5 @@ All pages support dark mode automatically via the user's system preference.
 - **Ponzology** – analyzes tokenomics descriptions for potentially predatory or unsustainable patterns, highlighting high APY claims, large team allocations and other irregularities. Visit [docs/ponzology](docs/ponzology/) to try it. When fetching tokenomics by contract address, Ponzology now pulls data from Coingecko, CoinMarketCap and the public Ethplorer API so supply information and basic metadata like holder counts are included alongside the description. The analysis checks for unrealistic supply numbers, missing max supply and other warning signs.
 
 The project is designed so new tools can be added easily under the `docs/` directory. Simply create a folder for your tool containing an `index.html`, `style.css`, and `script.js`.
+
+The site automatically redirects if you visit a lowercase path like `/toolz`. Use whichever capitalization you prefer.

--- a/docs/404.html
+++ b/docs/404.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Redirecting...</title>
+    <script>
+        (function() {
+            var path = window.location.pathname;
+            var lower = path.toLowerCase();
+            if (lower.startsWith('/toolz')) {
+                var remainder = path.substring('/toolz'.length);
+                var target = '/Toolz' + remainder + window.location.search + window.location.hash;
+                window.location.replace(target);
+            }
+        })();
+    </script>
+</head>
+<body>
+    <p>Redirecting...</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a custom 404 page that redirects from `/toolz` to `/Toolz`
- note automatic redirect for lowercase path in README

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_684e3286dd4c832a9c55b1da27163577