### PR TITLE
Add feature request submission

### DIFF
--- a/docs/ponzology/index.html
+++ b/docs/ponzology/index.html
@@ -18,6 +18,12 @@
         <textarea id="tokenomics" placeholder="Paste tokenomics description here..."></textarea>
         <button id="run">Run Analysis</button>
         <div id="results" class="results"></div>
+
+        <div class="feature-request">
+            <h2>Request a Feature</h2>
+            <textarea id="feature-text" placeholder="Describe your idea"></textarea>
+            <button id="feature-submit">Submit Request</button>
+        </div>
     </div>
     <script src="script.js"></script>
 </body>

--- a/docs/ponzology/script.js
+++ b/docs/ponzology/script.js
@@ -231,3 +231,46 @@ document.getElementById('run').addEventListener('click', () => {
 
     document.getElementById('results').innerHTML = html;
 });
+
+// Submit a feature request to the repository using the GitHub API.
+const featureBtn = document.getElementById('feature-submit');
+if (featureBtn) {
+    featureBtn.addEventListener('click', () => {
+        const text = document.getElementById('feature-text').value.trim();
+        if (!text) {
+            alert('Please enter a feature request.');
+            return;
+        }
+
+        let token = localStorage.getItem('ghToken') || '';
+        token = prompt('GitHub token with repo access:', token);
+        if (!token) return;
+        localStorage.setItem('ghToken', token);
+
+        const repo = 'BenGothard/Toolz';
+        const path = `feature-requests/${Date.now()}.txt`;
+        const body = {
+            message: 'Add feature request',
+            content: btoa(unescape(encodeURIComponent(text)))
+        };
+
+        fetch(`https://api.github.com/repos/${repo}/contents/${path}`, {
+            method: 'PUT',
+            headers: {
+                'Authorization': 'token ' + token,
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(body)
+        })
+        .then(r => r.json().then(d => ({ok: r.ok, data: d})))
+        .then(res => {
+            if (res.ok) {
+                alert('Feature request submitted!');
+                document.getElementById('feature-text').value = '';
+            } else {
+                alert(res.data.message || 'Failed to submit request');
+            }
+        })
+        .catch(() => alert('Network error while submitting request'));
+    });
+}

--- a/docs/ponzology/style.css
+++ b/docs/ponzology/style.css
@@ -75,6 +75,18 @@ button:hover {
     color: #080;
 }
 
+.feature-request {
+    margin-top: 2rem;
+}
+
+.feature-request textarea {
+    width: 100%;
+    height: 100px;
+    margin-bottom: 0.5rem;
+    padding: 0.5rem;
+    font-size: 1rem;
+}
+
 .nav-header {
     display: flex;
     align-items: center;
@@ -127,5 +139,11 @@ button:hover {
 
     .back-button {
         color: #66aaff;
+    }
+
+    .feature-request textarea {
+        background: #333;
+        color: #fff;
+        border: 1px solid #555;
     }
 }

--- a/feature-requests/README.md
+++ b/feature-requests/README.md
@@ -1,0 +1,6 @@
+# Feature Requests
+
+Text files in this folder are automatically created via the feature request forms on the product pages.
+Each file contains a user-submitted feature idea.
+
+Requests require a GitHub token with repo access to be submitted.


### PR DESCRIPTION
## Summary
- add `feature-requests` directory for submitted requests
- append a feature request form to the Ponzology page
- style the request form and include dark mode support
- implement client-side JS that stores a GitHub token locally and writes requests via the GitHub API

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684e38b93cdc832abe8401ed944e6bce