### PR TITLE
Move pages under /toolz

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ Toolz is a collection of lightweight, AI-powered browser tools for crypto invest
 
 All pages support dark mode automatically via the user's system preference.
 
-![Ponzology Demo](docs/ponzology/demo.gif)
+![Ponzology Demo](docs/toolz/ponzology/demo.gif)
 
 ## Available Tools
 
-- **Ponzology** – analyzes tokenomics descriptions for potentially predatory or unsustainable patterns, highlighting high APY claims, large team allocations and other irregularities. Visit [docs/ponzology](docs/ponzology/) to try it. When fetching tokenomics by contract address, Ponzology now pulls data from Coingecko, CoinMarketCap and the public Ethplorer API so supply information and basic metadata like holder counts are included alongside the description. The analysis checks for unrealistic supply numbers, missing max supply and other warning signs.
+- **Ponzology** – analyzes tokenomics descriptions for potentially predatory or unsustainable patterns, highlighting high APY claims, large team allocations and other irregularities. Visit [docs/toolz/ponzology](docs/toolz/ponzology/) to try it. When fetching tokenomics by contract address, Ponzology now pulls data from Coingecko, CoinMarketCap and the public Ethplorer API so supply information and basic metadata like holder counts are included alongside the description. The analysis checks for unrealistic supply numbers, missing max supply and other warning signs.
 
 The project is designed so new tools can be added easily under the `docs/` directory. Simply create a folder for your tool containing an `index.html`, `style.css`, and `script.js`.
 
-The site automatically redirects if you visit a lowercase path like `/toolz`. Use whichever capitalization you prefer.
+The site is served from the `/toolz` path on GitHub Pages.

--- a/docs/404.html
+++ b/docs/404.html
@@ -7,10 +7,9 @@
     <script>
         (function() {
             var path = window.location.pathname;
-            var lower = path.toLowerCase();
-            if (lower.startsWith('/toolz')) {
-                var remainder = path.substring('/toolz'.length);
-                var target = '/Toolz' + remainder + window.location.search + window.location.hash;
+            if (path.startsWith('/Toolz')) {
+                var remainder = path.substring('/Toolz'.length);
+                var target = '/toolz' + remainder + window.location.search + window.location.hash;
                 window.location.replace(target);
             }
         })();

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,24 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Toolz</title>
-    <link rel="stylesheet" href="style.css">
+  <meta charset="UTF-8">
+  <meta http-equiv="refresh" content="0; url=./toolz/">
+  <title>Redirecting...</title>
 </head>
 <body>
-    <header>
-        <h1>Toolz</h1>
-        <p>A growing collection of lightweight browser tools for crypto investors.</p>
-    </header>
-    <main>
-        <h2>Available Tools</h2>
-        <ul class="tool-list">
-            <li>
-                <a class="tool-button" href="ponzology/">Ponzology</a>
-                <span class="desc">Analyze tokenomics for predatory patterns.</span>
-            </li>
-        </ul>
-    </main>
+  <p>Redirecting to <a href="./toolz/">/toolz/</a>...</p>
 </body>
 </html>

--- a/docs/toolz/index.html
+++ b/docs/toolz/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Toolz</title>
+    <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+    <header>
+        <h1>Toolz</h1>
+        <p>A growing collection of lightweight browser tools for crypto investors.</p>
+    </header>
+    <main>
+        <h2>Available Tools</h2>
+        <ul class="tool-list">
+            <li>
+                <a class="tool-button" href="ponzology/">Ponzology</a>
+                <span class="desc">Analyze tokenomics for predatory patterns.</span>
+            </li>
+        </ul>
+    </main>
+</body>
+</html>

--- a/docs/toolz/ponzology/index.html
+++ b/docs/toolz/ponzology/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Ponzology</title>
   <link rel="stylesheet" href="style.css">
-  <script type="module" src="../util.js"></script>
+  <script type="module" src="../../util.js"></script>
   <script type="module" src="script.js" defer></script>
 </head>
 <body>

--- a/docs/toolz/ponzology/script.js
+++ b/docs/toolz/ponzology/script.js
@@ -1,4 +1,4 @@
-import { $, cacheFetch, toggleTheme } from '../util.js';
+import { $, cacheFetch, toggleTheme } from '../../util.js';
 
 const textEl = $('#text');
 const runBtn = $('#run');

--- a/docs/toolz/ponzology/style.css
+++ b/docs/toolz/ponzology/style.css
@@ -1,4 +1,4 @@
-@import '../toolz.css';
+@import '../../toolz.css';
 
 header{
   display:flex;


### PR DESCRIPTION
## Summary
- place docs under `/toolz` and add redirect from the old location
- update 404 logic to send `/Toolz` requests to lowercase `/toolz`
- fix relative paths in Ponzology tool
- note new location in README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684e401de4e0832a9f915ad25f4cd949