### PR TITLE
Set GitHub Pages landing page to tools UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="refresh" content="0; url=./docs/toolz/">
+  <title>Redirecting...</title>
+</head>
+<body>
+  <p>Redirecting to <a href="./docs/toolz/">Toolz</a>...</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add redirect index.html in repo root so the GitHub Pages site shows the Toolz UI instead of the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e49ba6390832abd87c4611a76e508