### PR TITLE
Add wiki search for Ponzology

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ All pages support dark mode automatically via the user's system preference.
 
 ## Available Tools
 
-- **Ponzology** – analyzes tokenomics descriptions for potentially predatory or unsustainable patterns, highlighting high APY claims, large team allocations and other irregularities. Visit [docs/toolz/ponzology](docs/toolz/ponzology/) to try it. When fetching tokenomics by contract address or $CASHTAG, Ponzology pulls data from Coingecko, CoinMarketCap and the public Ethplorer API so supply information and basic metadata like holder counts are included alongside the description. The analysis checks for unrealistic supply numbers, missing max supply and other warning signs.
+- **Ponzology** – analyzes tokenomics descriptions for potentially predatory or unsustainable patterns, highlighting high APY claims, large team allocations and other irregularities. Visit [docs/toolz/ponzology](docs/toolz/ponzology/) to try it. When fetching tokenomics by contract address or $CASHTAG, Ponzology pulls data from Coingecko, CoinMarketCap and the public Ethplorer API so supply information and basic metadata like holder counts are included alongside the description. A new Web Search option retrieves a short Wikipedia summary for additional context before running the analysis. The analysis checks for unrealistic supply numbers, missing max supply and other warning signs.
 
 The project is designed so new tools can be added easily under the `docs/` directory. Simply create a folder for your tool containing an `index.html`, `style.css`, and `script.js`.
 

--- a/docs/toolz/ponzology/index.html
+++ b/docs/toolz/ponzology/index.html
@@ -16,8 +16,10 @@
   <main class="container">
     <h1>Ponzology</h1>
     <p class="subtitle">Tokenomics risk analyzer</p>
+    <p class="instructions">Enter a contract address or $CASHTAG and click <strong>Fetch Tokenomics</strong> or paste a description below. Use <strong>Web Search</strong> to pull a short summary from Wikipedia, then hit <strong>Run Analysis</strong>.</p>
     <input id="contract" type="text" placeholder="Contract address or $CASHTAG (optional)">
     <button class="btn" id="fetch">Fetch Tokenomics</button>
+    <button class="btn" id="search">Web Search</button>
     <textarea id="text" placeholder="Paste tokenomics here..."></textarea>
     <button class="btn" id="run">Run Analysis</button>
     <div id="spinner" hidden>Loading...</div>

--- a/docs/toolz/ponzology/script.js
+++ b/docs/toolz/ponzology/script.js
@@ -3,6 +3,7 @@ import { $, cacheFetch, toggleTheme } from '../../util.js';
 const textEl = $('#text');
 const runBtn = $('#run');
 const fetchBtn = $('#fetch');
+const searchBtn = $('#search');
 const contractEl = $('#contract');
 const resultsEl = $('#results');
 const spinner = $('#spinner');
@@ -19,8 +20,26 @@ const patterns = [
  /burn\s+to\s+earn/i,
  /referral/i,
  /mlm/i,
- /locked\s+liquidity\s+forever/i
+/locked\s+liquidity\s+forever/i
 ];
+
+async function searchToken(){
+ const query = contractEl.value.trim();
+ if(!query) return;
+ searchBtn.disabled = true; spinner.hidden = false;
+ try{
+  const term = query.replace(/^\$/,'');
+  const data = await cacheFetch(`https://en.wikipedia.org/api/rest_v1/page/summary/${encodeURIComponent(term)}`);
+  if(data.extract){
+   textEl.value = data.extract + '\n\n' + textEl.value;
+  }else{
+   alert('No summary found');
+  }
+ }catch(e){
+  alert('Failed to fetch summary');
+ }
+ spinner.hidden = true; searchBtn.disabled = false;
+}
 
 function buildTokenomicsText(desc,supply,meta){
  let text='';
@@ -135,6 +154,7 @@ async function run(){
 
 runBtn.addEventListener('click', run);
 if(fetchBtn) fetchBtn.addEventListener('click', fetchTokenomics);
+if(searchBtn) searchBtn.addEventListener('click', searchToken);
 
 window.addEventListener('load', ()=>{
  const hash=location.hash.slice(1);

--- a/docs/toolz/ponzology/style.css
+++ b/docs/toolz/ponzology/style.css
@@ -15,3 +15,5 @@ header{
 
 #contract{width:100%;padding:0.5rem;margin-bottom:0.5rem;}
 #fetch{margin-bottom:0.5rem;}
+#search{margin-bottom:0.5rem;margin-left:0.5rem;}
+.instructions{margin-bottom:0.5rem;font-size:0.9rem;}


### PR DESCRIPTION
## Summary
- allow pulling a short Wikipedia summary when searching for a token
- add quick instructions under the Ponzology title

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684f01c9fad4832a9a95d7bb5448b79c