### PR TITLE
Rename Fetch Tokenomics to Search

### DIFF
--- a/docs/toolz/ponzology/index.html
+++ b/docs/toolz/ponzology/index.html
@@ -16,9 +16,9 @@
   <main class="container">
     <h1>Ponzology</h1>
     <p class="subtitle">Tokenomics risk analyzer</p>
-    <p class="instructions">Enter a contract address, $CASHTAG or project name and click <strong>Fetch Tokenomics</strong> to retrieve data. The tool uses your browser's AI search first and verifies the result against public data before falling back to other sources. You can also paste a description below and hit <strong>Run Analysis</strong>.</p>
+    <p class="instructions">Enter a contract address, $CASHTAG or project name and click <strong>Search</strong> to retrieve data. The tool uses your browser's AI search first and verifies the result against public data before falling back to other sources. You can also paste a description below and hit <strong>Run Analysis</strong>.</p>
     <input id="contract" type="text" placeholder="Contract address, $CASHTAG or project name">
-    <button class="btn" id="fetch">Fetch Tokenomics</button>
+    <button class="btn" id="search">Search</button>
     <textarea id="text" placeholder="Paste tokenomics here..."></textarea>
     <button class="btn" id="run">Run Analysis</button>
     <div id="spinner" hidden>Loading...</div>

--- a/docs/toolz/ponzology/script.js
+++ b/docs/toolz/ponzology/script.js
@@ -2,7 +2,7 @@ import { $, cacheFetch, toggleTheme } from '../../util.js';
 
 const textEl = $('#text');
 const runBtn = $('#run');
-const fetchBtn = $('#fetch');
+const searchBtn = $('#search');
 const contractEl = $('#contract');
 const resultsEl = $('#results');
 const spinner = $('#spinner');
@@ -78,10 +78,10 @@ function buildTokenomicsText(desc,supply,meta){
  return text;
 }
 
-async function fetchTokenomics(){
+async function search(){
  let query=contractEl.value.trim();
  if(!query) return;
- fetchBtn.disabled=true; spinner.hidden=false;
+ searchBtn.disabled=true; spinner.hidden=false;
  let addr=query;
  if(!/^0x[a-fA-F0-9]{40}$/.test(query)){
   addr=await aiSearchToken(query);
@@ -91,7 +91,7 @@ async function fetchTokenomics(){
     const search=await cacheFetch(`https://api.coingecko.com/api/v3/search?query=${encodeURIComponent(sym)}`);
     const coin=(search.coins||[]).find(c=>c.symbol.toLowerCase()===sym || c.name.toLowerCase()===sym || c.name.toLowerCase().includes(sym));
     if(!coin){
-     alert('Token not found'); spinner.hidden=true; fetchBtn.disabled=false; return;
+     alert('Token not found'); spinner.hidden=true; searchBtn.disabled=false; return;
     }
     const data=await cacheFetch(`https://api.coingecko.com/api/v3/coins/${coin.id}`);
     addr=data.platforms&&data.platforms.ethereum;
@@ -102,9 +102,9 @@ async function fetchTokenomics(){
      const desc=data.description&&data.description.en;
      const text=buildTokenomicsText(desc,supply,meta);
      if(text) textEl.value=text; else alert('Token description not found');
-     spinner.hidden=true; fetchBtn.disabled=false; return;
+     spinner.hidden=true; searchBtn.disabled=false; return;
     }
-   }catch(e){alert('Failed to fetch token info'); spinner.hidden=true; fetchBtn.disabled=false; return;}
+   }catch(e){alert('Failed to fetch token info'); spinner.hidden=true; searchBtn.disabled=false; return;}
   }
  }
  const fetchEthplorer=async()=>{
@@ -124,8 +124,8 @@ async function fetchTokenomics(){
    const extra=await fetchEthplorer();
    const text=buildTokenomicsText(desc,{...supply,...extra.supply},extra.meta);
    if(text) textEl.value=text; else alert('Token description not found');
-  }catch(e){alert('Failed to fetch tokenomics');}
- };
+  }catch(e){alert('Failed to search');}
+};
  try{
   const data=await cacheFetch(`https://api.coingecko.com/api/v3/coins/ethereum/contract/${addr}`);
   const desc=data.description&&data.description.en;
@@ -135,8 +135,8 @@ async function fetchTokenomics(){
   const extra=await fetchEthplorer();
   const text=buildTokenomicsText(desc,{...supply,...extra.supply},extra.meta);
   if(text) textEl.value=text; else await tryCoinMarketCap(slug);
-}catch(e){alert('Failed to fetch tokenomics');}
-spinner.hidden=true; fetchBtn.disabled=false;
+}catch(e){alert('Failed to search');}
+spinner.hidden=true; searchBtn.disabled=false;
 }
 
 function render(res){
@@ -174,7 +174,7 @@ async function run(){
 }
 
 runBtn.addEventListener('click', run);
-if(fetchBtn) fetchBtn.addEventListener('click', fetchTokenomics);
+if(searchBtn) searchBtn.addEventListener('click', search);
 
 window.addEventListener('load', ()=>{
  const hash=location.hash.slice(1);


### PR DESCRIPTION
## Summary
- rename **Fetch Tokenomics** button to **Search** and update instructions
- update `script.js` to look up the new `search` button and rename `fetchTokenomics()` to `search()`
- adjust error messages and event listener for renamed functionality

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684f1f764720832a8477e336aded048b