### PR TITLE
Fix spacing after search button

### DIFF
--- a/docs/toolz/ponzology/style.css
+++ b/docs/toolz/ponzology/style.css
@@ -14,5 +14,6 @@ header{
 #spinner{margin-top:1rem;}
 
 #contract{width:100%;padding:0.5rem;margin-bottom:0.5rem;}
+#search{margin-bottom:0.5rem;}
 #fetch{margin-bottom:0.5rem;}
 .instructions{margin-bottom:0.5rem;font-size:0.9rem;}


### PR DESCRIPTION
## Summary
- add bottom margin to the search button so the textarea isn't flush against it

## Testing
- `npx -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f54785258832a81b538fe2474412f