### PR TITLE
Fix token search partial match bug

### DIFF
--- a/docs/toolz/ponzology/script.js
+++ b/docs/toolz/ponzology/script.js
@@ -90,8 +90,12 @@ async function search(){
   if(!addr){
    const sym=query.replace(/^\$/,'').toLowerCase();
    try{
-    const search=await cacheFetch(`https://api.coingecko.com/api/v3/search?query=${encodeURIComponent(sym)}`);
-    const coin=(search.coins||[]).find(c=>c.symbol.toLowerCase()===sym || c.name.toLowerCase()===sym || c.name.toLowerCase().includes(sym));
+   const search=await cacheFetch(`https://api.coingecko.com/api/v3/search?query=${encodeURIComponent(sym)}`);
+   const coins = search.coins || [];
+   const regex = new RegExp(`\\b${sym}\\b`, 'i');
+   const coin = coins.find(c => c.symbol.toLowerCase() === sym)
+              || coins.find(c => c.name.toLowerCase() === sym)
+              || coins.find(c => regex.test(c.name));
     if(!coin){
      alert('Token not found'); spinner.hidden=true; searchBtn.disabled=false; return;
     }


### PR DESCRIPTION
## Summary
- adjust search logic in `ponzology` so tokens are matched on symbol or exact name before loose matches

## Testing
- `node --check docs/toolz/ponzology/script.js`

------
https://chatgpt.com/codex/tasks/task_e_684f889f1958832a935a8353b286837c