### PR TITLE
Add simple UI example

### DIFF
--- a/js/simple_ui.js
+++ b/js/simple_ui.js
@@ -1,0 +1,29 @@
+import { loadAgents } from './agent_loader.js';
+import { runAgent } from './fallback_router.js';
+
+const perfToggle = document.getElementById('performanceToggle');
+const runButton = document.getElementById('runButton');
+const inputArea = document.getElementById('inputText');
+const outputArea = document.getElementById('outputArea');
+const select = document.getElementById('agentSelect');
+
+(async () => {
+  const agents = await loadAgents();
+  agents.forEach(agent => {
+    const option = document.createElement('option');
+    option.value = agent.name;
+    option.textContent = agent.name;
+    select.appendChild(option);
+  });
+
+  runButton.addEventListener('click', async () => {
+    const agentName = select.value;
+    const agent = agents.find(a => a.name === agentName);
+    if (!agent) {
+      outputArea.textContent = 'Agent not found';
+      return;
+    }
+    const result = await runAgent(agent, { text: inputArea.value }, perfToggle.checked);
+    outputArea.textContent = JSON.stringify(result, null, 2);
+  });
+})();

--- a/simple_ui.html
+++ b/simple_ui.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Toolz - Simple UI</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="./css/styles.css" />
+</head>
+<body class="bg-gray-100 text-gray-900">
+  <div class="container mx-auto p-4">
+    <header class="mb-4">
+      <h1 class="text-3xl font-bold">Toolz Simple UI</h1>
+    </header>
+    <section class="mb-4">
+      <label class="flex items-center space-x-2">
+        <input type="checkbox" id="performanceToggle" class="form-checkbox" />
+        <span>Performance Mode</span>
+      </label>
+    </section>
+    <section class="mb-4 flex items-center space-x-2">
+      <select id="agentSelect" class="border p-2"></select>
+      <button id="runButton" class="bg-blue-500 text-white px-2 py-1">Run</button>
+    </section>
+    <textarea id="inputText" class="w-full border p-2" rows="4" placeholder="Type your request here..."></textarea>
+    <pre id="outputArea" class="mt-2 bg-gray-100 p-2"></pre>
+  </div>
+  <script type="module" src="./js/simple_ui.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- provide `simple_ui.html` with a single input box and agent selector
- add `js/simple_ui.js` to power the new UI

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68502248cb4c832a95dd4b354a6938bc