### PR TITLE
Fix agent loader paths and add dark mode UI improvements

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,2 +1,2 @@
 body { font-family: sans-serif; }
-.agent-panel { border: 1px solid #ddd; padding: 1rem; background:white; }
+.agent-panel { border: 1px solid #444; padding: 1rem; background:#1f2937; color:#f3f4f6; }

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
   <link rel="stylesheet" href="./css/styles.css" />
 </head>
-<body class="bg-gray-100 text-gray-900">
+<body class="bg-gray-900 text-gray-100">
   <div class="container mx-auto p-4">
     <header class="mb-4">
       <h1 class="text-3xl font-bold">Toolz</h1>
@@ -18,13 +18,14 @@
         <input type="checkbox" id="performanceToggle" class="form-checkbox" />
         <span>Performance Mode</span>
       </label>
+      <p class="text-xs text-gray-400">When disabled, agents run locally. Enabling may use cloud fallbacks for better performance.</p>
     </section>
     <section class="mb-4 flex items-center space-x-2">
       <select id="agentSelect" class="border p-2"></select>
       <button id="runButton" class="bg-blue-500 text-white px-2 py-1">Run</button>
     </section>
-    <textarea id="inputText" class="w-full border p-2" rows="4" placeholder="Type your request here..."></textarea>
-    <pre id="outputArea" class="mt-2 bg-gray-100 p-2"></pre>
+    <textarea id="inputText" class="w-full border p-2 bg-gray-800 text-gray-100" rows="4" placeholder="Type your request here..."></textarea>
+    <pre id="outputArea" class="mt-2 bg-gray-800 p-2"></pre>
   </div>
   <script type="module" src="./js/simple_ui.js"></script>
 </body>

--- a/js/agent_loader.js
+++ b/js/agent_loader.js
@@ -5,10 +5,10 @@ export function registerAgent(agent) {
 
 export async function loadAgents() {
   const modules = [
-    './agents/summarize_agent.js',
-    './agents/sentiment_agent.js',
-    './agents/speech_agent.js',
-    './agents/embed_agent.js'
+    '../agents/summarize_agent.js',
+    '../agents/sentiment_agent.js',
+    '../agents/speech_agent.js',
+    '../agents/embed_agent.js'
   ];
   await Promise.all(modules.map((m) => import(m)));
   return agents;


### PR DESCRIPTION
## Summary
- fix agent import paths so modules load
- default to dark UI theme
- explain performance mode
- adjust agent panel styles

## Testing
- `node -e "import('./js/agent_loader.js').then(m=>m.loadAgents().then(a=>console.log('loaded',a.length)).catch(e=>console.error(e)))"` *(fails: Only URLs with a scheme in: file, data, and node are supported)*

------
https://chatgpt.com/codex/tasks/task_e_68502c738f60832ab9c2c670400ece3e