### PR TITLE
Add status terminal to UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ python3 -m http.server
 1. Choose a tool from the drop-down menu on the page.
 2. Enter or paste text into the input box.
 3. Click **Run** to execute the selected agent.
-4. The agent's output will appear below the input field.
+4. Watch the status panel under the selector for progress updates.
+5. The agent's output will appear below the input field.
 
 ## Adding Agents
 

--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
       <select id="agentSelect" class="border p-2"></select>
       <button id="runButton" class="bg-blue-500 text-white px-2 py-1">Run</button>
     </section>
+    <pre id="statusTerminal" class="mb-2 bg-gray-800 p-2 text-xs h-16 overflow-y-auto font-mono text-green-400"></pre>
     <p class="text-xs text-gray-400 mb-4">Select a tool, enter text, then press
       <strong>Run</strong> to execute the agent.</p>
     <textarea id="inputText" class="w-full border p-2 bg-gray-800 text-gray-100" rows="4" placeholder="Type your request here..."></textarea>

--- a/js/simple_ui.js
+++ b/js/simple_ui.js
@@ -6,6 +6,14 @@ const runButton = document.getElementById('runButton');
 const inputArea = document.getElementById('inputText');
 const outputArea = document.getElementById('outputArea');
 const select = document.getElementById('agentSelect');
+const statusTerminal = document.getElementById('statusTerminal');
+
+function logStatus(message) {
+  const lines = statusTerminal.textContent.split('\n').filter(Boolean);
+  lines.push(message);
+  while (lines.length > 3) lines.shift();
+  statusTerminal.textContent = lines.join('\n');
+}
 
 (async () => {
   const agents = await loadAgents();
@@ -21,9 +29,17 @@ const select = document.getElementById('agentSelect');
     const agent = agents.find(a => a.name === agentName);
     if (!agent) {
       outputArea.textContent = 'Agent not found';
+      logStatus('Agent not found');
       return;
     }
-    const result = await runAgent(agent, { text: inputArea.value }, perfToggle.checked);
-    outputArea.textContent = JSON.stringify(result, null, 2);
+    logStatus(`Running ${agentName}...`);
+    try {
+      const result = await runAgent(agent, { text: inputArea.value }, perfToggle.checked);
+      outputArea.textContent = JSON.stringify(result, null, 2);
+      logStatus('Done');
+    } catch (err) {
+      outputArea.textContent = 'Error: ' + err.message;
+      logStatus('Error: ' + err.message);
+    }
   });
 })();


### PR DESCRIPTION
## Summary
- add status terminal element below model selector and run button
- update simple_ui.js to log status messages (last 3 lines)
- document the status panel in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68502ec4c430832a86e78c239ffdc631