### PR TITLE
Fix agent selector visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
       <p class="text-xs text-gray-400">When disabled, agents run locally. Enabling may use cloud fallbacks for better performance.</p>
     </section>
     <section class="mb-2 flex items-center space-x-2">
-      <select id="agentSelect" class="border p-2"></select>
+      <select id="agentSelect" class="border p-2 bg-gray-800 text-gray-100"></select>
       <button id="runButton" class="bg-blue-500 text-white px-2 py-1">Run</button>
     </section>
     <pre id="statusTerminal" class="mb-2 bg-gray-800 p-2 text-xs h-16 overflow-y-auto font-mono text-green-400"></pre>


### PR DESCRIPTION
## Summary
- fix invisible text in agent dropdown by styling with dark background and light text

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_68502f74fce0832ab3505ef1ade47c64