### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,25 @@
+name: Deploy to GitHub Pages
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/configure-pages@v3
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: .
+      - uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ Agents live in the `agents/` directory and register themselves via `registerAgen
 
 Push the repository to GitHub and enable **GitHub Pages** in the repository settings. Ensure the `.nojekyll` file is present.
 
+A GitHub Actions workflow is provided in `.github/workflows/deploy.yml`. The
+workflow automatically deploys the `main` branch to GitHub Pages whenever you
+push updates. Simply push the repository to GitHub and wait for the workflow to
+finish before visiting your page.
+
 ## Privacy vs Performance
 
 The checkbox on the main page toggles performance mode. When disabled, all agents run locally. When enabled, agents may opt to use cloud fallbacks.


### PR DESCRIPTION
## Summary
- automate deployment with GitHub Actions
- document the workflow in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685043291b3c832a8f975ae130084dc1